### PR TITLE
Link to TPDL paper on publications page is bad

### DIFF
--- a/_publications/2022-09-15-rise-of-github.md
+++ b/_publications/2022-09-15-rise-of-github.md
@@ -6,7 +6,7 @@ excerpt: ''
 date: 2022-09-15
 url-slug: rise-of-github
 venue: 'Theory and Practice of Digital Libraries'
-paperurl: 'https://elescmalla.github.io/files/TPDL-rise-of-github.pdf'
+paperurl: 'https://elescamilla.github.io/files/TPDL-rise-of-github.pdf'
 citation: 'Escamilla, E., Klein, M., Cooper, T., Rampin, V., Weigle, M.C., Nelson, M.L. (2022). The Rise of GitHub in Scholarly Publications. In: <i>Linking Theory and Practice of Digital Libraries</i>. TPDL 2022. Lecture Notes in Computer Science, vol 13541. Springer, Cham.<a href="https://doi.org/10.1007/978-3-031-16802-4_15">https://doi.org/10.1007/978-3-031-16802-4_15</a>'
 ---
 

--- a/_publications/2022-09-15-rise-of-github.md
+++ b/_publications/2022-09-15-rise-of-github.md
@@ -6,7 +6,7 @@ excerpt: ''
 date: 2022-09-15
 url-slug: rise-of-github
 venue: 'Theory and Practice of Digital Libraries'
-paperurl: 'elescmalla.github.io/files/TPDL-rise-of-github.pdf'
+paperurl: 'https://elescmalla.github.io/files/TPDL-rise-of-github.pdf'
 citation: 'Escamilla, E., Klein, M., Cooper, T., Rampin, V., Weigle, M.C., Nelson, M.L. (2022). The Rise of GitHub in Scholarly Publications. In: <i>Linking Theory and Practice of Digital Libraries</i>. TPDL 2022. Lecture Notes in Computer Science, vol 13541. Springer, Cham.<a href="https://doi.org/10.1007/978-3-031-16802-4_15">https://doi.org/10.1007/978-3-031-16802-4_15</a>'
 ---
 


### PR DESCRIPTION
The issue is twofold:

* A lack of scheme (i.e., https) causes the URI to be resolved relative to the base URI. The relative URI contains the full hostname, thus causing the intended URI to be appended onto the base URI.
* The subdomain (your username @elescamilla) is misspelled in the hostname of the linked URI.

This PR fixes both of those issues. An example of the link working can be seen in the rendered fork of this repo at https://machawk1.github.io/elescamilla.github.io/publications/ .